### PR TITLE
Avoid "open_basedir restriction" error

### DIFF
--- a/includes/class-wp-smime.php
+++ b/includes/class-wp-smime.php
@@ -107,7 +107,7 @@ class WP_SMIME {
      * @return array|FALSE An array with two keys, `headers` and `message`, wherein the message is encrypted.
      */
     public static function encrypt ( $message, $headers, $certificates ) {
-        $infile  = tempnam( '/tmp', 'wp_email_' );
+        $infile  = tempnam( sys_get_temp_dir(), 'wp_email_' );
         $outfile = $infile . '.enc';
 
         $plaintext  = ( is_array( $headers ) ) ? implode( "\n", $headers ) : $headers;


### PR DESCRIPTION
Fixes a problem where S/MIME email sending fails due to a web hoster restriction. By using `sys_get_temp_dir()` it's possible to use a different configured path from the unix default '/tmp'.
<https://php.net/manual/en/function.tempnam.php#93256>